### PR TITLE
Update dependency review workflow

### DIFF
--- a/.github/workflows/dep_review.yaml
+++ b/.github/workflows/dep_review.yaml
@@ -1,4 +1,5 @@
-name: 'Dependency Review'
+name: Dependency Review
+
 on:
   pull_request:
     branches:
@@ -7,14 +8,31 @@ on:
 
 jobs:
   dependency-review:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this is needed for gh cli
     steps:
-      - name: 'Checkout Repository'
+      # Checking if repo is public. If it's not, dependency review will be skipped.
+      - name: Check if repo is public
+        run: |
+          response=$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" repos/${{ github.repository}} | jq -r '.visibility')
+          if [ "$response" == "public" ]; then
+            echo "Repository is Public. Going ahead with dependency Review."
+            echo 'is_public=true' >> $GITHUB_ENV
+          fi
+
+      # Checkout the repository using actions/checkout
+      - name: "Checkout Repository"
+        if: env.is_public == 'true'
         uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
-      - name: 'Dependency Review'
+
+      # Review dependency changes for any known vulnerabilities using https://github.com/actions/dependency-review-action
+      - name: "Dependency Review"
+        if: env.is_public == 'true'
         uses: actions/dependency-review-action@2ce029c676cacb6112c47192ee072c7f783330c5
         with:
           comment-summary-in-pr: always


### PR DESCRIPTION
- Added logic to check if the repo is public or not using gh cli.
- The gh cli needs the GITHUB_TOKEN to make the necessary API call.
- If the repo is not public, then dependency review will be skipped, and the workflow will pass.